### PR TITLE
Mitigate error caused by Scoop Installation of Spotify

### DIFF
--- a/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
+++ b/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
@@ -17,7 +17,7 @@ public class SpotifyProcess extends WinProcess {
 
     // Spotify track id
     private static final String PREFIX_SPOTIFY_TRACK = "spotify:track:";
-    private static final long[] ADDRESSES_OFFSET_TRACK_ID = {
+    private static final long[] OFFSETS_TRACK_ID = {
             0x1499F0, // Vanilla
             0xFEFE8 // Scoop
     };
@@ -60,7 +60,7 @@ public class SpotifyProcess extends WinProcess {
 
         // Check all offsets for valid track id
         long addressTrackId = -1;
-        for (long trackIdOffset : ADDRESSES_OFFSET_TRACK_ID) {
+        for (long trackIdOffset : OFFSETS_TRACK_ID) {
             addressTrackId = chromeElfAddress + trackIdOffset;
             if (addressTrackId == -1 || !this.isTrackIdValid(this.readTrackId(addressTrackId))) {
                 throw new IllegalStateException("Could not find track id in memory");

--- a/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
+++ b/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
@@ -54,16 +54,15 @@ public class SpotifyProcess extends WinProcess {
 
         // Find address of track id (Located in the chrome_elf.dll module)
         long chromeElfAddress = chromeElfModule.getBaseOfDll();
+
+        if(this.findInMemory(0, 0x0FFFFFFF, "Scoop Apps".getBytes()) != -1) {
+            ADDRESS_OFFSET_TRACK_ID = 0xFEFE8;
+        }
+
         long addressTrackId = chromeElfAddress + ADDRESS_OFFSET_TRACK_ID;
 
         if (addressTrackId == -1 || !this.isTrackIdValid(this.readTrackId(addressTrackId))) {
-            if(ADDRESS_OFFSET_TRACK_ID == 0x1499F0) {
-                ADDRESS_OFFSET_TRACK_ID = 0xFEFE8;
-                throw new IllegalStateException("Could not find track id in memory, trying different Address Offset");
-            } else {
-                ADDRESS_OFFSET_TRACK_ID = 0x1499F0;
-                throw new IllegalStateException("Could not find track id in memory");
-            }
+            throw new IllegalStateException("Could not find track id in memory");
         }
 
         if (DEBUG) {

--- a/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
+++ b/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
@@ -17,7 +17,7 @@ public class SpotifyProcess extends WinProcess {
 
     // Spotify track id
     private static final String PREFIX_SPOTIFY_TRACK = "spotify:track:";
-    private static final long ADDRESS_OFFSET_TRACK_ID = 0x1499F0;
+    private static long ADDRESS_OFFSET_TRACK_ID = 0x1499F0; //FEFE8
 
     private final long addressTrackId;
     private final PlaybackAccessor playbackAccessor;
@@ -57,7 +57,13 @@ public class SpotifyProcess extends WinProcess {
         long addressTrackId = chromeElfAddress + ADDRESS_OFFSET_TRACK_ID;
 
         if (addressTrackId == -1 || !this.isTrackIdValid(this.readTrackId(addressTrackId))) {
-            throw new IllegalStateException("Could not find track id in memory");
+            if(ADDRESS_OFFSET_TRACK_ID == 0x1499F0) {
+                ADDRESS_OFFSET_TRACK_ID = 0xFEFE8;
+                throw new IllegalStateException("Could not find track id in memory, trying different Address Offset");
+            } else {
+                ADDRESS_OFFSET_TRACK_ID = 0x1499F0;
+                throw new IllegalStateException("Could not find track id in memory");
+            }
         }
 
         if (DEBUG) {


### PR DESCRIPTION
TLDR:
This mitigates error #3 in a decent and fashionable manner.
One could go and try to find ``Scoop Apps\\Spotify.ink``, which i was unable to pointer-find via 3 tools, although it exists.
