### PR TITLE
Fix Song detection and update Offsets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ out
 .gradle
 *.iml
 build
+run/

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'de.labystudio'
-version '1.1.14'
+version '1.1.15'
 
 compileJava {
     sourceCompatibility = '1.8'

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'de.labystudio'
-version '1.1.15'
+version '1.1.16'
 
 compileJava {
     sourceCompatibility = '1.8'

--- a/src/main/java/de/labystudio/spotifyapi/platform/windows/api/playback/MemoryPlaybackAccessor.java
+++ b/src/main/java/de/labystudio/spotifyapi/platform/windows/api/playback/MemoryPlaybackAccessor.java
@@ -29,10 +29,10 @@ public class MemoryPlaybackAccessor implements PlaybackAccessor {
         this.process = process;
 
         // Create pointer registry to calculate the absolute addresses using the relative offsets
-        this.pointerRegistry = new PointerRegistry(0x0CFF4498, address);
-        this.pointerRegistry.register("position", 0x0CFF4810);
-        this.pointerRegistry.register("length", 0x0CFF4820);
-        this.pointerRegistry.register("is_playing", 0x0CFF4850); // 1=true, 0=false
+        this.pointerRegistry = new PointerRegistry(0x0AD59F08, address);
+        this.pointerRegistry.register("position", 0x0AD5A290);
+        this.pointerRegistry.register("length", 0x0AD5A2A0);
+        this.pointerRegistry.register("is_playing", 0x0AD5A2D8); // 1=true, 0=false
 
         this.update();
     }

--- a/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
+++ b/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
@@ -18,8 +18,8 @@ public class SpotifyProcess extends WinProcess {
     // Spotify track id
     private static final String PREFIX_SPOTIFY_TRACK = "spotify:track:";
     private static final long[] OFFSETS_TRACK_ID = {
-            0x14C9F0, // Vanilla
-            0x102178 // Scoop
+            0x14C9F0, // 64-Bit
+            0x102178 // 32-Bit
     };
 
     private final long addressTrackId;
@@ -62,13 +62,17 @@ public class SpotifyProcess extends WinProcess {
         long addressTrackId = -1;
         for (long trackIdOffset : OFFSETS_TRACK_ID) {
             addressTrackId = chromeElfAddress + trackIdOffset;
-            if (addressTrackId == -1 || !this.isTrackIdValid(this.readTrackId(addressTrackId))) {
-                throw new IllegalStateException("Could not find track id in memory");
+            if (addressTrackId != -1 && this.isTrackIdValid(this.readTrackId(addressTrackId))) {
+                // If the offset works, exit the loop
+                break;
             }
-            break;
         }
 
-        if (DEBUG) {
+        if (addressTrackId == -1) {
+            throw new IllegalStateException("Could not find track id in memory");
+        }
+
+    if (DEBUG) {
             System.out.printf(
                     "Found track id address: %s (+%s) [%s%s]%n",
                     Long.toHexString(addressTrackId),

--- a/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
+++ b/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
@@ -18,8 +18,8 @@ public class SpotifyProcess extends WinProcess {
     // Spotify track id
     private static final String PREFIX_SPOTIFY_TRACK = "spotify:track:";
     private static final long[] OFFSETS_TRACK_ID = {
-            0x14C9F0, // 64-Bit
-            0xFEFE8 // 32-Bit
+            0x14C9F0, // Vanilla
+            0x102178 // Scoop
     };
 
     private final long addressTrackId;

--- a/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
+++ b/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
@@ -18,7 +18,7 @@ public class SpotifyProcess extends WinProcess {
     // Spotify track id
     private static final String PREFIX_SPOTIFY_TRACK = "spotify:track:";
     private static final long[] OFFSETS_TRACK_ID = {
-            0x14FA30, // 64-Bit (latest)
+            0x14FA30, // 64-Bit (1.2.21.1104.g42cf0a50)
             0x106198, // 32-Bit (1.2.21.1104.g42cf0a50)
             0x14C9F0, // 64-Bit (Old)
             0x102178, // 32-Bit (Old)
@@ -66,7 +66,6 @@ public class SpotifyProcess extends WinProcess {
         long addressTrackId = -1;
         for (long trackIdOffset : OFFSETS_TRACK_ID) {
             addressTrackId = chromeElfAddress + trackIdOffset;
-            System.out.println(this.isTrackIdValid(this.readTrackId(addressTrackId)));
             if (addressTrackId != -1 && this.isTrackIdValid(this.readTrackId(addressTrackId))) {
                 // If the offset works, exit the loop
                 break;

--- a/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
+++ b/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
@@ -18,8 +18,10 @@ public class SpotifyProcess extends WinProcess {
     // Spotify track id
     private static final String PREFIX_SPOTIFY_TRACK = "spotify:track:";
     private static final long[] OFFSETS_TRACK_ID = {
-            0x14C9F0, // 64-Bit
-            0x102178, // 32-Bit
+            0x14FA30, // 64-Bit (latest)
+            0x106198, // 32-Bit (latest)
+            0x14C9F0, // 64-Bit (Old)
+            0x102178, // 32-Bit (Old)
             0x1499F0, // 64-Bit (Old)
             0xFEFE8 // 32-Bit (Old)
     };

--- a/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
+++ b/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
@@ -176,16 +176,12 @@ public class SpotifyProcess extends WinProcess {
      * @return True if the track ID is valid, false otherwise.
      */
     public boolean isTrackIdValid(String trackId) {
-        for (char c : trackId.toCharArray()) {
-            if (!isValidCharacter(c)) {
+        char[] charArray = trackId.toCharArray();
+        for (char c : charArray) {
+            if (Character.isLetterOrDigit(c) && c == 0) {
                 return false;
             }
         }
         return true;
-    }
-
-    private boolean isValidCharacter(char c) {
-        // Check if the character is within a valid range
-        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
     }
 }

--- a/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
+++ b/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
@@ -18,8 +18,8 @@ public class SpotifyProcess extends WinProcess {
     // Spotify track id
     private static final String PREFIX_SPOTIFY_TRACK = "spotify:track:";
     private static final long[] OFFSETS_TRACK_ID = {
-            0x14C9F0, // Vanilla
-            0xFEFE8 // Scoop
+            0x14C9F0, // 64-Bit
+            0xFEFE8 // 32-Bit
     };
 
     private final long addressTrackId;

--- a/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
+++ b/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
@@ -176,9 +176,8 @@ public class SpotifyProcess extends WinProcess {
      * @return True if the track ID is valid, false otherwise.
      */
     public boolean isTrackIdValid(String trackId) {
-        char[] charArray = trackId.toCharArray();
-        for (char c : charArray) {
-            if (Character.isLetterOrDigit(c) && c == 0) {
+        for (char c : trackId.toCharArray()) {
+            if (!Character.isLetterOrDigit(c)) {
                 return false;
             }
         }

--- a/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
+++ b/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
@@ -19,7 +19,7 @@ public class SpotifyProcess extends WinProcess {
     private static final String PREFIX_SPOTIFY_TRACK = "spotify:track:";
     private static final long[] OFFSETS_TRACK_ID = {
             0x14FA30, // 64-Bit (latest)
-            0x106198, // 32-Bit (latest)
+            0x106198, // 32-Bit (1.2.21.1104.g42cf0a50)
             0x14C9F0, // 64-Bit (Old)
             0x102178, // 32-Bit (Old)
             0x1499F0, // 64-Bit (Old)
@@ -66,6 +66,7 @@ public class SpotifyProcess extends WinProcess {
         long addressTrackId = -1;
         for (long trackIdOffset : OFFSETS_TRACK_ID) {
             addressTrackId = chromeElfAddress + trackIdOffset;
+            System.out.println(this.isTrackIdValid(this.readTrackId(addressTrackId)));
             if (addressTrackId != -1 && this.isTrackIdValid(this.readTrackId(addressTrackId))) {
                 // If the offset works, exit the loop
                 break;
@@ -177,10 +178,15 @@ public class SpotifyProcess extends WinProcess {
      */
     public boolean isTrackIdValid(String trackId) {
         for (char c : trackId.toCharArray()) {
-            if (c == 0) {
+            if (!isValidCharacter(c)) {
                 return false;
             }
         }
         return true;
+    }
+
+    private boolean isValidCharacter(char c) {
+        // Check if the character is within a valid range
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
     }
 }

--- a/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
+++ b/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
@@ -18,7 +18,7 @@ public class SpotifyProcess extends WinProcess {
     // Spotify track id
     private static final String PREFIX_SPOTIFY_TRACK = "spotify:track:";
     private static final long[] OFFSETS_TRACK_ID = {
-            0x1499F0, // Vanilla
+            0x14C9F0, // Vanilla
             0xFEFE8 // Scoop
     };
 

--- a/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
+++ b/src/main/java/de/labystudio/spotifyapi/platform/windows/api/spotify/SpotifyProcess.java
@@ -19,7 +19,9 @@ public class SpotifyProcess extends WinProcess {
     private static final String PREFIX_SPOTIFY_TRACK = "spotify:track:";
     private static final long[] OFFSETS_TRACK_ID = {
             0x14C9F0, // 64-Bit
-            0x102178 // 32-Bit
+            0x102178, // 32-Bit
+            0x1499F0, // 64-Bit (Old)
+            0xFEFE8 // 32-Bit (Old)
     };
 
     private final long addressTrackId;
@@ -72,7 +74,7 @@ public class SpotifyProcess extends WinProcess {
             throw new IllegalStateException("Could not find track id in memory");
         }
 
-    if (DEBUG) {
+        if (DEBUG) {
             System.out.printf(
                     "Found track id address: %s (+%s) [%s%s]%n",
                     Long.toHexString(addressTrackId),

--- a/src/test/java/SpotifyProcessTest.java
+++ b/src/test/java/SpotifyProcessTest.java
@@ -1,5 +1,6 @@
 import de.labystudio.spotifyapi.platform.windows.api.WinProcess;
 import de.labystudio.spotifyapi.platform.windows.api.jna.Psapi;
+import de.labystudio.spotifyapi.platform.windows.api.playback.MemoryPlaybackAccessor;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -17,12 +18,22 @@ public class SpotifyProcessTest {
         System.out.println("Track Id Address: 0x" + Long.toHexString(addressTrackId));
 
         long addressOfPlayback = process.findAddressOfText(0, 0x0FFFFFFF, "playlist", (address, index) -> {
-            return process.hasText(address + 408, "context", "autoplay");
-
-            // process.hasText(address + 128, "your_library", "home")
+            return process.hasText(address + 408, "context", "autoplay")
+                    && process.hasText(address + 128, "your_library", "home")
+                    && new MemoryPlaybackAccessor(process, address).isValid();
         });
 
-        System.out.println("Playback Address: 0x" + Long.toHexString(addressOfPlayback));
+        if (addressOfPlayback == -1) {
+            addressOfPlayback = process.findAddressOfText(0, 0x0FFFFFFF, "album", (address, index) -> {
+                return process.hasText(address + 408, "context", "autoplay")
+                        && process.hasText(address + 128, "your_library", "home")
+                        && new MemoryPlaybackAccessor(process, address).isValid();
+            });
+        }
+
+        MemoryPlaybackAccessor accessor = new MemoryPlaybackAccessor(process, addressOfPlayback);
+        System.out.println("Playback Address: 0x" + Long.toHexString(addressOfPlayback) + " (" + (accessor.isValid() ? "valid" : "invalid") + ")");
+        System.out.println("Position: " + accessor.getPosition());
     }
 
     public static void printModules(WinProcess process, long targetAddress) {


### PR DESCRIPTION
32-Bit is currently throwing a Nullpointer Exception with garbled TrackID
![image](https://github.com/LabyStudio/java-spotify-api/assets/45071533/8e2c15b4-6a1a-4ddf-b0a3-de902b2a0f1a)

Investigating atm.

EDIT: 
So its able to find the title name of the song in the 32-Bit with a 64-bit offset.
IT will also print true to the trackID of the 64-Bit offset in a 32-Bit application
![image](https://github.com/LabyStudio/java-spotify-api/assets/45071533/c301df07-9b19-4501-8c54-cf7255e158ec)


Atleast, it lasted 2 weeks this time haha