### PR TITLE
Fix thread leak

### DIFF
--- a/src/main/java/de/labystudio/spotifyapi/SpotifyAPI.java
+++ b/src/main/java/de/labystudio/spotifyapi/SpotifyAPI.java
@@ -36,7 +36,6 @@ public interface SpotifyAPI {
      */
     SpotifyAPI initialize(SpotifyConfiguration configuration);
 
-
     /**
      * Initialize the SpotifyAPI and connect to the Spotify process asynchronously.
      *
@@ -46,7 +45,6 @@ public interface SpotifyAPI {
     default CompletableFuture<SpotifyAPI> initializeAsync(SpotifyConfiguration configuration) {
         return CompletableFuture.supplyAsync(() -> this.initialize(configuration));
     }
-
 
     /**
      * Initialize the SpotifyAPI and connect to the Spotify process asynchronously.
@@ -119,7 +117,6 @@ public interface SpotifyAPI {
      */
     boolean isConnected();
 
-
     /**
      * Returns true if the background process is running.
      *
@@ -154,4 +151,11 @@ public interface SpotifyAPI {
      * Disconnect from the Spotify application and stop all background tasks.
      */
     void stop();
+
+    /**
+     * Similar to {@link SpotifyAPI#stop()} but releases any held resources.
+     * <p>
+     * Should only be called if there is no intent to reuse this instance.
+     */
+    void shutdown();
 }


### PR DESCRIPTION
Fixes #15.

Creating a new executor each call to `AbstractTickSpotifyAPI#initialize` even if properly shutdown leads to high memory usage. While this memory would eventually be reclaimed by the JVM, it feels correct to avoid it if possible. As such I opted to create a single executor per instance of `AbstractTickSpotifyAPI`. This necessitated the creation of `SpotifyAPI#shutdown` to support occasions where the user of the library chooses to not use the built-in auto-reconnect functionality in favour of their own.