### PR TITLE
Use daemon threads for executors, simplify reconnect

### DIFF
--- a/src/main/java/de/labystudio/spotifyapi/open/OpenSpotifyAPI.java
+++ b/src/main/java/de/labystudio/spotifyapi/open/OpenSpotifyAPI.java
@@ -47,7 +47,11 @@ public class OpenSpotifyAPI {
     public static final String URL_API_GRAPHQL = "https://api-partner.spotify.com/pathfinder/v1/query";
     public static final String URL_API_SERVER_TIME = "https://open.spotify.com/api/server-time";
 
-    private final Executor executor = Executors.newSingleThreadExecutor();
+    private final Executor executor = Executors.newSingleThreadExecutor(runnable -> {
+        Thread thread = new Thread(runnable, "spotify-open-api");
+        thread.setDaemon(true);
+        return thread;
+    });
 
     private final Cache<BufferedImage> imageCache = new Cache<>(10);
     private final Cache<OpenTrack> openTrackCache = new Cache<>(100);

--- a/src/main/java/de/labystudio/spotifyapi/platform/AbstractTickSpotifyAPI.java
+++ b/src/main/java/de/labystudio/spotifyapi/platform/AbstractTickSpotifyAPI.java
@@ -30,7 +30,11 @@ public abstract class AbstractTickSpotifyAPI implements SpotifyAPI {
 
     protected SpotifyConfiguration configuration;
 
-    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+        Thread thread = new Thread(runnable, "spotify-api-tick");
+        thread.setDaemon(true);
+        return thread;
+    });
 
     private ScheduledFuture<?> task;
 
@@ -87,14 +91,15 @@ public abstract class AbstractTickSpotifyAPI implements SpotifyAPI {
             this.onTick();
         } catch (Exception e) {
             this.timeLastException = System.currentTimeMillis();
-            this.stop();
 
             // Fire on disconnect
             this.listeners.forEach(listener -> listener.onDisconnect(e));
 
-            // Restart the process
-            if (this.configuration.isAutoReconnect()) {
-                this.initialize(this.configuration);
+            // Stop ticking entirely if auto reconnect is disabled.
+            // Otherwise keep the existing task running: the exception timeout guard
+            // skips ticks until the reconnect delay passes, then onTick re-establishes the connection.
+            if (!this.configuration.isAutoReconnect()) {
+                this.stop();
             }
         }
     }


### PR DESCRIPTION
Tick + open-api executors now use named daemon threads so a forgotten shutdown() no longer keeps the JVM alive.

Reconnect no longer stops+re-initializes from the tick thread (which self-interrupted via cancel(true) and re-ran setup needlessly). On auto reconnect the existing task keeps running; the cooldown guard skips ticks until the delay passes, then onTick re-establishes the connection.